### PR TITLE
Ytpl limit increase, added error handling response for Google API Limit, and adjusted playStream Settings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1420,10 +1420,13 @@ try {
             });
 
             let dispatcher = connection.playStream(ytdl(video.url, {
-              filter: 'audioonly'
+              filter: 'audioonly',
+              quality: 'highestaudio',
+              highWaterMark: 1<<25
             }), {
               bitrate: musicbot.bitRate,
-              volume: (queue.volume / 100)
+              volume: (queue.volume / 100),
+              highWaterMark: 1
             })
 
             connection.on('error', (error) => {

--- a/index.js
+++ b/index.js
@@ -504,8 +504,7 @@ try {
             if (ran >= playlist.items.length) {
               console.log(queue);
               if (queue.songs.length >= 1) musicbot.executeQueue(msg, queue);
-              if (queue.songs.length === 0 && index > 0) msg.channel.send(musicbot.note('fail', `Something went wrong. Try again! (If the problem continues, check your daily Google API quota)`));
-              else if (index == 0) msg.channel.send(musicbot.note('fail', `Coudln't get any songs from that playlist!`))
+              if (index == 0) msg.channel.send(musicbot.note('fail', `Coudln't get any songs from that playlist!`))
               else if (index == 1) msg.channel.send(musicbot.note('note', `Queued one song.`));
               else if (index > 1) msg.channel.send(musicbot.note('note', `Queued ${index} songs.`));
             }

--- a/index.js
+++ b/index.js
@@ -486,7 +486,7 @@ try {
         if (playid.toString()
         .includes('&t=')) playid = playid.split('&t=')[0];
 
-        ytpl(playid, function(err, playlist) {
+        ytpl(playid, {limit: musicbot.maxQueueSize}, function(err, playlist) {
           if(err) return msg.channel.send(musicbot.note('fail', `Something went wrong fetching that playlist!`));
           if (playlist.items.length <= 0) return msg.channel.send(musicbot.note('fail', `Couldn't get any videos from that playlist.`));
           if (playlist.total_items >= musicbot.maxQueueSize && musicbot.maxQueueSize != 0) return msg.channel.send(musicbot.note('fail', `Too many videos to queue. A maximum of ` + musicbot.maxQueueSize + ` is allowed.`));


### PR DESCRIPTION
I updated the ytpl call to use the options object. This allows for passing musicbot.maxQueueSize as a playlist limit to ytpl and finally allows a playlist limit of over 100 (ytpl defaults limit to 100 if not defined).

I Added error handling bot responses for Google API Limits which also prevents unhandled promise rejection warnings and reduces errors filling up the logs.

I changed the dispatcher playStream settings to change the highWaterMark. Not sure if this is needed for everyone but this fixed some jitter issues I had during playback. This also stopped my stream from ending prematurely. It used to end a song as much as like 45 seconds early. It doesn't switch songs as fast as before but for me it's acceptable. 

![image](https://user-images.githubusercontent.com/22354631/68626842-43670d80-04aa-11ea-9314-fe8e5a0a0204.png)
![image](https://user-images.githubusercontent.com/22354631/68626852-49f58500-04aa-11ea-85e3-8e327c9df6f7.png)
